### PR TITLE
Fix pd-nagios missing required field error mesage

### DIFF
--- a/bin/pd-nagios
+++ b/bin/pd-nagios
@@ -99,7 +99,7 @@ class NagiosEvent:
         if not NagiosEvent.REQUIRED_FIELDS[self._notification_type].issubset(self._details.keys()):
             msg = "Missing fields for type '{0}'.  {1} required".format(
                 self._notification_type,
-                ", ".join(self._required_fields())
+                ", ".join(NagiosEvent.REQUIRED_FIELDS[self._notification_type])
                 )
             raise ValueError(msg)
 


### PR DESCRIPTION
This fixes non-existent reference to self._required_fields(). No such method nor property exists. Logical concludes next closest thing is NagiosEvent.REQUIRED_FIELDS[self._notification_type].
